### PR TITLE
Fixed DeviceMemory and Buffer lock, flush and invalidate functions.

### DIFF
--- a/source/Ashes/Ashes/Src/Buffer/Buffer.cpp
+++ b/source/Ashes/Ashes/Src/Buffer/Buffer.cpp
@@ -32,23 +32,23 @@ namespace ashes
 		doBindMemory();
 	}
 
-	uint8_t * BufferBase::lock( uint32_t offset
-		, uint32_t size
+	uint8_t * BufferBase::lock( uint64_t offset
+		, uint64_t size
 		, MemoryMapFlags flags )const
 	{
 		assert( m_storage && "The resource is not bound to a device memory object." );
 		return m_storage->lock( offset, size, flags );
 	}
 
-	void BufferBase::invalidate( uint32_t offset
-		, uint32_t size )const
+	void BufferBase::invalidate( uint64_t offset
+		, uint64_t size )const
 	{
 		assert( m_storage && "The resource is not bound to a device memory object." );
 		return m_storage->invalidate( offset, size );
 	}
 
-	void BufferBase::flush( uint32_t offset
-		, uint32_t size )const
+	void BufferBase::flush( uint64_t offset
+		, uint64_t size )const
 	{
 		assert( m_storage && "The resource is not bound to a device memory object." );
 		return m_storage->flush( offset, size );

--- a/source/Ashes/Ashes/Src/Buffer/Buffer.hpp
+++ b/source/Ashes/Ashes/Src/Buffer/Buffer.hpp
@@ -94,8 +94,8 @@ namespace ashes
 		*\return
 		*	\p nullptr si le mapping a échoué.
 		*/
-		uint8_t * lock( uint32_t offset
-			, uint32_t size
+		uint8_t * lock( uint64_t offset
+			, uint64_t size
 			, MemoryMapFlags flags )const;
 		/**
 		*\~english
@@ -113,8 +113,8 @@ namespace ashes
 		*\param[in] size
 		*	La taille en octets de la mémoire mappée.
 		*/
-		void invalidate( uint32_t offset
-			, uint32_t size )const;
+		void invalidate( uint64_t offset
+			, uint64_t size )const;
 		/**
 		*\~english
 		*\brief
@@ -131,8 +131,8 @@ namespace ashes
 		*\param[in] size
 		*	La taille en octets de la mémoire mappée.
 		*/
-		void flush( uint32_t offset
-			, uint32_t size )const;
+		void flush( uint64_t offset
+			, uint64_t size )const;
 		/**
 		*\~english
 		*\brief
@@ -351,9 +351,9 @@ namespace ashes
 		*\brief
 		*	Maps a range of the buffer's memory in RAM.
 		*\param[in] offset
-		*	The range beginning offset.
-		*\param[in] size
-		*	The range size.
+		*	The range elements beginning offset.
+		*\param[in] count
+		*	The range elements count.
 		*\param[in] flags
 		*	The mapping flags.
 		*\return
@@ -362,65 +362,64 @@ namespace ashes
 		*\brief
 		*	Mappe la mémoire du tampon en RAM.
 		*\param[in] offset
-		*	L'offset à partir duquel la mémoire du tampon est mappée.
-		*\param[in] size
-		*	La taille en octets de la mémoire à mapper.
+		*	L'offset à partir duquel les éléments du tampon sont mappés.
+		*\param[in] count
+		*	Le nombre d'éléments à mapper.
 		*\param[in] flags
 		*	Indicateurs de configuration du mapping.
 		*\return
 		*	\p nullptr si le mapping a échoué.
 		*/
-		inline T * lock( uint32_t offset
-			, uint32_t size
+		inline T * lock( uint64_t offset
+			, uint64_t count
 			, MemoryMapFlags flags )const
 		{
-			return reinterpret_cast< T * >( m_buffer->lock( uint32_t( offset * sizeof( T ) )
-				, uint32_t( size * sizeof( T ) )
-				, flags ) );
+			auto size = doComputeSize( count, offset );
+			return reinterpret_cast< T * >( m_buffer->lock( offset, size, flags ) );
 		}
 		/**
 		*\~english
 		*\brief
 		*	Updates the VRAM.
 		*\param[in] offset
-		*	The mapped memory starting offset.
-		*\param[in] size
-		*	The range size.
+		*	The mapped elements starting offset.
+		*\param[in] count
+		*	The range elements count.
 		*\~french
 		*\brief
 		*	Met à jour la VRAM.
 		*\param[in] offset
-		*	L'offset de la mémoire mappée.
-		*\param[in] size
-		*	La taille en octets de la mémoire mappée.
+		*	L'offset des éléments mappés.
+		*\param[in] count
+		*	Le nombre d'éléments mappés.
 		*/
-		inline void flush( uint32_t offset
-			, uint32_t size )const
+		inline void flush( uint64_t offset
+			, uint64_t count )const
 		{
-			m_buffer->flush( uint32_t( offset * sizeof( T ) )
-				, uint32_t( size * sizeof( T ) ) );
+			auto size = doComputeSize( count, offset );
+			m_buffer->flush( offset, size );
 		}
 		/**
 		*\~english
 		*\brief
 		*	Invalidates the buffer content.
 		*\param[in] offset
-		*	The mapped memory starting offset.
-		*\param[in] size
-		*	The range size.
+		*	The mapped elements starting offset.
+		*\param[in] count
+		*	The range elements count.
 		*\~french
 		*\brief
 		*	Invalide le contenu du tampon.
 		*\param[in] offset
-		*	L'offset de la mémoire mappée.
-		*\param[in] size
-		*	La taille en octets de la mémoire mappée.
+		*	L'offset des éléments mappés.
+		*\param[in] count
+		*	Le nombre d'éléments mappés.
 		*/
-		inline void invalidate( uint32_t offset
-			, uint32_t size )const
+		inline void invalidate( uint64_t offset
+			, uint64_t count )const
 		{
-			m_buffer->invalidate( uint32_t( offset * sizeof( T ) )
-				, uint32_t( size * sizeof( T ) ) );
+			auto size = doComputeSize( count, offset );
+			m_buffer->invalidate( offset, size );
 		}
 		/**
 		*\~english
@@ -436,6 +435,25 @@ namespace ashes
 		}
 
 	private:
+		uint64_t doComputeSize( uint64_t count, uint64_t & offset )const
+		{
+			offset *= sizeof( T );
+			count *= sizeof( T );
+			auto const aligned = getAlignedSize( count
+				, uint32_t( m_device.getProperties().limits.nonCoherentAtomSize ) );
+			auto result = count == m_buffer->getSize()
+				? ( offset == 0ull
+					? ~( 0ull )
+					: aligned )
+				: ( offset + count == m_buffer->getSize()
+					? count
+					: aligned );
+			assert( result == ~( 0ull ) || offset + result <= m_buffer->getSize() );
+			return result;
+		}
+
+	private:
+		Device const & m_device;
 		BufferBasePtr m_buffer;
 	};
 	/**

--- a/source/Ashes/Ashes/Src/Buffer/Buffer.inl
+++ b/source/Ashes/Ashes/Src/Buffer/Buffer.inl
@@ -1,4 +1,4 @@
-﻿/*
+/*
 This file belongs to Ashes.
 See LICENSE file in root folder.
 */
@@ -9,7 +9,8 @@ namespace ashes
 		, uint32_t count
 		, BufferTargets target
 		, MemoryPropertyFlags flags )
-		: m_buffer{ device.createBuffer( uint32_t( count * sizeof( T ) )
+		: m_device{ device }
+		, m_buffer{ device.createBuffer( uint32_t( count * sizeof( T ) )
 			, target
 			, flags ) }
 	{

--- a/source/Ashes/Ashes/Src/Buffer/StagingBuffer.cpp
+++ b/source/Ashes/Ashes/Src/Buffer/StagingBuffer.cpp
@@ -13,22 +13,6 @@ See LICENSE file in root folder.
 
 namespace ashes
 {
-	namespace
-	{
-		inline uint32_t getAlignedSize( uint32_t size, uint32_t align )
-		{
-			uint32_t result = 0u;
-
-			while ( size > align )
-			{
-				size -= align;
-				result += align;
-			}
-
-			return result + align;
-		}
-	}
-
 	StagingBuffer::StagingBuffer( Device const & device
 		, BufferTargets target
 		, uint32_t size )
@@ -43,9 +27,11 @@ namespace ashes
 		, uint32_t size )const
 	{
 		assert( size <= getBuffer().getSize() );
-		auto mappedSize = std::min( getBuffer().getSize()
-			, getAlignedSize( size
-				, uint32_t( m_device.getPhysicalDevice().getProperties().limits.nonCoherentAtomSize ) ) );
+		auto mappedSize = getAlignedSize( size
+			, uint32_t( m_device.getPhysicalDevice().getProperties().limits.nonCoherentAtomSize ) );
+		mappedSize = mappedSize > getBuffer().getSize()
+			? ~( 0ull )
+			: mappedSize;
 		auto buffer = static_cast< BufferBase const & >( getBuffer() ).lock( 0u
 			, mappedSize
 			, MemoryMapFlag::eWrite | MemoryMapFlag::eInvalidateRange );
@@ -150,9 +136,11 @@ namespace ashes
 		, uint32_t size )const
 	{
 		assert( size <= getBuffer().getSize() );
-		auto mappedSize = std::min( getBuffer().getSize()
-			, getAlignedSize( size
-				, uint32_t( m_device.getPhysicalDevice().getProperties().limits.nonCoherentAtomSize ) ) );
+		auto mappedSize = getAlignedSize( size
+			, uint32_t( m_device.getPhysicalDevice().getProperties().limits.nonCoherentAtomSize ) );
+		mappedSize = mappedSize > getBuffer().getSize()
+			? ~( 0ull )
+			: mappedSize;
 		auto buffer = static_cast< BufferBase const & >( getBuffer() ).lock( 0u
 			, mappedSize
 			, MemoryMapFlag::eRead );

--- a/source/Ashes/Ashes/Src/Miscellaneous/DeviceMemory.hpp
+++ b/source/Ashes/Ashes/Src/Miscellaneous/DeviceMemory.hpp
@@ -15,6 +15,38 @@ namespace ashes
 	/**
 	*\~english
 	*\brief
+	*	Computes an aligned size.
+	*\param[in] size
+	*	The unaligned size.
+	*\param[in] align
+	*	The alignment value.
+	*\return
+	*	The aligned size.
+	*\~french
+	*\brief
+	*	Calcule une taille alignée.
+	*\param[in] size
+	*	La taille non alignée.
+	*\param[in] align
+	*	La valeur d'alignement.
+	*\return
+	*	La taille alignée.
+	*/
+	inline uint64_t getAlignedSize( uint64_t size, uint32_t align )
+	{
+		uint64_t result = 0u;
+
+		while ( size > align )
+		{
+			size -= align;
+			result += align;
+		}
+
+		return result + align;
+	}
+	/**
+	*\~english
+	*\brief
 	*	A device memory object.
 	*\~french
 	*\brief
@@ -61,8 +93,8 @@ namespace ashes
 		*\return
 		*	\p nullptr si le mapping a échoué.
 		*/
-		virtual uint8_t * lock( uint32_t offset
-			, uint32_t size
+		virtual uint8_t * lock( uint64_t offset
+			, uint64_t size
 			, ashes::MemoryMapFlags flags )const = 0;
 		/**
 		*\~english
@@ -80,8 +112,8 @@ namespace ashes
 		*\param[in] size
 		*	La taille en octets de la mémoire mappée.
 		*/
-		virtual void invalidate( uint32_t offset
-			, uint32_t size )const = 0;
+		virtual void invalidate( uint64_t offset
+			, uint64_t size )const = 0;
 		/**
 		*\~english
 		*\brief
@@ -98,8 +130,8 @@ namespace ashes
 		*\param[in] size
 		*	La taille en octets de la mémoire mappée.
 		*/
-		virtual void flush( uint32_t offset
-			, uint32_t size )const = 0;
+		virtual void flush( uint64_t offset
+			, uint64_t size )const = 0;
 		/**
 		*\~english
 		*\brief

--- a/source/Ashes/D3D11Renderer/CMakeLists.txt
+++ b/source/Ashes/D3D11Renderer/CMakeLists.txt
@@ -132,53 +132,55 @@ set( ENABLED_RENDERERS
 	PARENT_SCOPE
 )
 
-if ( ASHES_STATIC_RENDERERS )
-	#We install each .lib/.a in <install_dir>/lib folder
-	install(
-		TARGETS ${PROJECT_NAME}
-		COMPONENT ${PROJECT_NAME}
-		CONFIGURATIONS Release RelWithDebInfo
-		EXPORT ${PROJECT_NAME}
-		ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Release
-	)
-	install(
-		TARGETS ${PROJECT_NAME}
-		COMPONENT ${PROJECT_NAME}
-		CONFIGURATIONS Debug
-		EXPORT ${PROJECT_NAME}
-		ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Debug
-	)
-else ()
-	if ( WIN32 )
-		#We install each .dll in <install_dir>/bin folder
+if ( BUILD_ASHES )
+	if ( ASHES_STATIC_RENDERERS )
+		#We install each .lib/.a in <install_dir>/lib folder
 		install(
 			TARGETS ${PROJECT_NAME}
 			COMPONENT ${PROJECT_NAME}
 			CONFIGURATIONS Release RelWithDebInfo
 			EXPORT ${PROJECT_NAME}
-			RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Release
+			ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Release
 		)
 		install(
 			TARGETS ${PROJECT_NAME}
 			COMPONENT ${PROJECT_NAME}
 			CONFIGURATIONS Debug
 			EXPORT ${PROJECT_NAME}
-			RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Debug
+			ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Debug
 		)
 	else ()
-		#We install each .so in <install_dir>/lib folder
-		install(
-			TARGETS ${PROJECT_NAME}
-			COMPONENT ${PROJECT_NAME}
-			CONFIGURATIONS Release RelWithDebInfo
-			EXPORT ${PROJECT_NAME}
-			LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Release
-		)
-		install(
-			TARGETS ${PROJECT_NAME}
-			COMPONENT ${PROJECT_NAME}
-			CONFIGURATIONS Debug
-			LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Debug
-		)
-	endif()
+		if ( WIN32 )
+			#We install each .dll in <install_dir>/bin folder
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Release RelWithDebInfo
+				EXPORT ${PROJECT_NAME}
+				RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Release
+			)
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Debug
+				EXPORT ${PROJECT_NAME}
+				RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Debug
+			)
+		else ()
+			#We install each .so in <install_dir>/lib folder
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Release RelWithDebInfo
+				EXPORT ${PROJECT_NAME}
+				LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Release
+			)
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Debug
+				LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Debug
+			)
+		endif()
+	endif ()
 endif ()

--- a/source/Ashes/D3D11Renderer/Src/Buffer/D3D11UniformBuffer.cpp
+++ b/source/Ashes/D3D11Renderer/Src/Buffer/D3D11UniformBuffer.cpp
@@ -5,23 +5,6 @@
 
 namespace d3d11_renderer
 {
-	namespace
-	{
-		uint32_t doGetAlignedSize( uint32_t size, uint32_t align )
-		{
-			uint32_t result = 0u;
-			auto align32 = uint32_t( align );
-
-			while ( size > align )
-			{
-				size -= align32;
-				result += align32;
-			}
-
-			return result + align32;
-		}
-	}
-
 	UniformBuffer::UniformBuffer( ashes::Device const & device
 		, uint32_t count
 		, uint32_t size
@@ -40,7 +23,7 @@ namespace d3d11_renderer
 
 	uint32_t UniformBuffer::getAlignedSize( uint32_t size )const
 	{
-		return doGetAlignedSize( size
-			, uint32_t( static_cast< Device const & >( m_device ).getPhysicalDevice().getProperties().limits.minUniformBufferOffsetAlignment ) );
+		return uint32_t( ashes::getAlignedSize( size
+			, uint32_t( static_cast< Device const & >( m_device ).getPhysicalDevice().getProperties().limits.minUniformBufferOffsetAlignment ) ) );
 	}
 }

--- a/source/Ashes/D3D11Renderer/Src/Miscellaneous/D3D11DeviceMemory.cpp
+++ b/source/Ashes/D3D11Renderer/Src/Miscellaneous/D3D11DeviceMemory.cpp
@@ -52,8 +52,8 @@ namespace d3d11_renderer
 			safeRelease( m_buffer );
 		}
 
-		uint8_t * lock( uint32_t offset
-			, uint32_t size
+		uint8_t * lock( uint64_t offset
+			, uint64_t size
 			, ashes::MemoryMapFlags flags )const override
 		{
 			ID3D11DeviceContext * context;
@@ -76,13 +76,13 @@ namespace d3d11_renderer
 			return result + offset;
 		}
 
-		void flush( uint32_t offset
-			, uint32_t size )const override
+		void flush( uint64_t offset
+			, uint64_t size )const override
 		{
 		}
 
-		void invalidate( uint32_t offset
-			, uint32_t size )const override
+		void invalidate( uint64_t offset
+			, uint64_t size )const override
 		{
 		}
 
@@ -161,8 +161,8 @@ namespace d3d11_renderer
 		{
 		}
 
-		uint8_t * lock( uint32_t offset
-			, uint32_t size
+		uint8_t * lock( uint64_t offset
+			, uint64_t size
 			, ashes::MemoryMapFlags flags )const override
 		{
 			ID3D11DeviceContext * context;
@@ -185,13 +185,13 @@ namespace d3d11_renderer
 			return result;
 		}
 
-		void flush( uint32_t offset
-			, uint32_t size )const override
+		void flush( uint64_t offset
+			, uint64_t size )const override
 		{
 		}
 
-		void invalidate( uint32_t offset
-			, uint32_t size )const override
+		void invalidate( uint64_t offset
+			, uint64_t size )const override
 		{
 		}
 
@@ -258,8 +258,8 @@ namespace d3d11_renderer
 		{
 		}
 
-		uint8_t * lock( uint32_t offset
-			, uint32_t size
+		uint8_t * lock( uint64_t offset
+			, uint64_t size
 			, ashes::MemoryMapFlags flags )const override
 		{
 			ID3D11DeviceContext * context;
@@ -282,13 +282,13 @@ namespace d3d11_renderer
 			return result;
 		}
 
-		void flush( uint32_t offset
-			, uint32_t size )const override
+		void flush( uint64_t offset
+			, uint64_t size )const override
 		{
 		}
 
-		void invalidate( uint32_t offset
-			, uint32_t size )const override
+		void invalidate( uint64_t offset
+			, uint64_t size )const override
 		{
 		}
 
@@ -370,8 +370,8 @@ namespace d3d11_renderer
 		{
 		}
 
-		uint8_t * lock( uint32_t offset
-			, uint32_t size
+		uint8_t * lock( uint64_t offset
+			, uint64_t size
 			, ashes::MemoryMapFlags flags )const override
 		{
 			ID3D11DeviceContext * context;
@@ -394,13 +394,13 @@ namespace d3d11_renderer
 			return result;
 		}
 
-		void flush( uint32_t offset
-			, uint32_t size )const override
+		void flush( uint64_t offset
+			, uint64_t size )const override
 		{
 		}
 
-		void invalidate( uint32_t offset
-			, uint32_t size )const override
+		void invalidate( uint64_t offset
+			, uint64_t size )const override
 		{
 		}
 
@@ -464,21 +464,21 @@ namespace d3d11_renderer
 	{
 	}
 
-	uint8_t * DeviceMemory::lock( uint32_t offset
-		, uint32_t size
+	uint8_t * DeviceMemory::lock( uint64_t offset
+		, uint64_t size
 		, ashes::MemoryMapFlags flags )const
 	{
 		return m_impl->lock( offset, size, flags );
 	}
 
-	void DeviceMemory::flush( uint32_t offset
-		, uint32_t size )const
+	void DeviceMemory::flush( uint64_t offset
+		, uint64_t size )const
 	{
 		m_impl->flush( offset, size );
 	}
 
-	void DeviceMemory::invalidate( uint32_t offset
-		, uint32_t size )const
+	void DeviceMemory::invalidate( uint64_t offset
+		, uint64_t size )const
 	{
 		m_impl->invalidate( offset, size );
 	}

--- a/source/Ashes/D3D11Renderer/Src/Miscellaneous/D3D11DeviceMemory.hpp
+++ b/source/Ashes/D3D11Renderer/Src/Miscellaneous/D3D11DeviceMemory.hpp
@@ -30,13 +30,13 @@ namespace d3d11_renderer
 				, ashes::MemoryRequirements const & requirements
 				, ashes::MemoryPropertyFlags flags );
 			virtual ~DeviceMemoryImpl() = default;
-			virtual uint8_t * lock( uint32_t offset
-				, uint32_t size
+			virtual uint8_t * lock( uint64_t offset
+				, uint64_t size
 				, ashes::MemoryMapFlags flags )const = 0;
-			virtual void flush( uint32_t offset
-				, uint32_t size )const = 0;
-			virtual void invalidate( uint32_t offset
-				, uint32_t size )const = 0;
+			virtual void flush( uint64_t offset
+				, uint64_t size )const = 0;
+			virtual void invalidate( uint64_t offset
+				, uint64_t size )const = 0;
 			virtual void unlock()const = 0;
 
 		protected:
@@ -81,19 +81,19 @@ namespace d3d11_renderer
 		/**
 		*\copydoc	ashes::DeviceMemory::lock
 		*/
-		uint8_t * lock( uint32_t offset
-			, uint32_t size
+		uint8_t * lock( uint64_t offset
+			, uint64_t size
 			, ashes::MemoryMapFlags flags )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::flush
 		*/
-		void flush( uint32_t offset
-			, uint32_t size )const override;
+		void flush( uint64_t offset
+			, uint64_t size )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::invalidate
 		*/
-		void invalidate( uint32_t offset
-			, uint32_t size )const override;
+		void invalidate( uint64_t offset
+			, uint64_t size )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::unlock
 		*/

--- a/source/Ashes/Gl3Renderer/CMakeLists.txt
+++ b/source/Ashes/Gl3Renderer/CMakeLists.txt
@@ -113,55 +113,57 @@ if ( OpenGL_FOUND )
 		PARENT_SCOPE
 	)
 
-	if ( ASHES_STATIC_RENDERERS )
-		#We install each .lib/.a in <install_dir>/lib folder
-		install(
-			TARGETS ${PROJECT_NAME}
-			COMPONENT ${PROJECT_NAME}
-			CONFIGURATIONS Release RelWithDebInfo
-			EXPORT ${PROJECT_NAME}
-			ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Release
-		)
-		install(
-			TARGETS ${PROJECT_NAME}
-			COMPONENT ${PROJECT_NAME}
-			CONFIGURATIONS Debug
-			EXPORT ${PROJECT_NAME}
-			ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Debug
-		)
-	else ()
-		if ( WIN32 )
-			#We install each .dll in <install_dir>/bin folder
+	if ( BUILD_ASHES )
+		if ( ASHES_STATIC_RENDERERS )
+			#We install each .lib/.a in <install_dir>/lib folder
 			install(
 				TARGETS ${PROJECT_NAME}
 				COMPONENT ${PROJECT_NAME}
 				CONFIGURATIONS Release RelWithDebInfo
 				EXPORT ${PROJECT_NAME}
-				RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Release
+				ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Release
 			)
 			install(
 				TARGETS ${PROJECT_NAME}
 				COMPONENT ${PROJECT_NAME}
 				CONFIGURATIONS Debug
 				EXPORT ${PROJECT_NAME}
-				RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Debug
+				ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Debug
 			)
 		else ()
-			#We install each .so in <install_dir>/lib folder
-			install(
-				TARGETS ${PROJECT_NAME}
-				COMPONENT ${PROJECT_NAME}
-				CONFIGURATIONS Release RelWithDebInfo
-				EXPORT ${PROJECT_NAME}
-				LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Release
-			)
-			install(
-				TARGETS ${PROJECT_NAME}
-				COMPONENT ${PROJECT_NAME}
-				CONFIGURATIONS Debug
-				LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Debug
-			)
-		endif()
+			if ( WIN32 )
+				#We install each .dll in <install_dir>/bin folder
+				install(
+					TARGETS ${PROJECT_NAME}
+					COMPONENT ${PROJECT_NAME}
+					CONFIGURATIONS Release RelWithDebInfo
+					EXPORT ${PROJECT_NAME}
+					RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Release
+				)
+				install(
+					TARGETS ${PROJECT_NAME}
+					COMPONENT ${PROJECT_NAME}
+					CONFIGURATIONS Debug
+					EXPORT ${PROJECT_NAME}
+					RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Debug
+				)
+			else ()
+				#We install each .so in <install_dir>/lib folder
+				install(
+					TARGETS ${PROJECT_NAME}
+					COMPONENT ${PROJECT_NAME}
+					CONFIGURATIONS Release RelWithDebInfo
+					EXPORT ${PROJECT_NAME}
+					LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Release
+				)
+				install(
+					TARGETS ${PROJECT_NAME}
+					COMPONENT ${PROJECT_NAME}
+					CONFIGURATIONS Debug
+					LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Debug
+				)
+			endif()
+		endif ()
 	endif ()
 else ()
 	if ( NOT OpenGL_FOUND )

--- a/source/Ashes/Gl3Renderer/Src/Buffer/GlUniformBuffer.cpp
+++ b/source/Ashes/Gl3Renderer/Src/Buffer/GlUniformBuffer.cpp
@@ -17,20 +17,6 @@ namespace gl_renderer
 			}();
 			return result;
 		}
-
-		uint32_t doGetAlignedSize( uint32_t size, uint32_t align )
-		{
-			uint32_t result = 0u;
-			auto align32 = uint32_t( align );
-
-			while ( size > align )
-			{
-				size -= align32;
-				result += align32;
-			}
-
-			return result + align32;
-		}
 	}
 
 	UniformBuffer::UniformBuffer( Device const & device
@@ -52,6 +38,7 @@ namespace gl_renderer
 
 	uint32_t UniformBuffer::getAlignedSize( uint32_t size )const
 	{
-		return doGetAlignedSize( size, getOffsetAlignment( m_device ) );
+		return uint32_t( ashes::getAlignedSize( size
+			, getOffsetAlignment( m_device ) ) );
 	}
 }

--- a/source/Ashes/Gl3Renderer/Src/Miscellaneous/GlDeviceMemory.cpp
+++ b/source/Ashes/Gl3Renderer/Src/Miscellaneous/GlDeviceMemory.cpp
@@ -178,8 +178,8 @@ namespace gl_renderer
 				}
 			}
 
-			uint8_t * lock( uint32_t offset
-				, uint32_t size
+			uint8_t * lock( uint64_t offset
+				, uint64_t size
 				, ashes::MemoryMapFlags flags )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local texture" );
@@ -192,16 +192,16 @@ namespace gl_renderer
 				auto result = glLogCall( context
 					, glMapBufferRange
 					, GL_BUFFER_TARGET_PIXEL_UNPACK
-					, offset
-					, size
+					, GLintptr( offset )
+					, GLsizei( size == ~( 0ull ) ? m_requirements.size : size )
 					, m_mapFlags );
 				assertDebugValue( m_isLocked, false );
 				setDebugValue( m_isLocked, result != nullptr );
 				return reinterpret_cast< uint8_t * >( result );
 			}
 
-			void flush( uint32_t offset
-				, uint32_t size )const override
+			void flush( uint64_t offset
+				, uint64_t size )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local texture" );
 				assertDebugValue( m_isLocked, true );
@@ -209,12 +209,12 @@ namespace gl_renderer
 				glLogCall( context
 					, glFlushMappedBufferRange
 					, GL_BUFFER_TARGET_PIXEL_UNPACK
-					, offset
-					, size );
+					, GLintptr( offset )
+					, GLsizei( size == ~( 0ull ) ? m_requirements.size : size ) );
 			}
 
-			void invalidate( uint32_t offset
-				, uint32_t size )const override
+			void invalidate( uint64_t offset
+				, uint64_t size )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local texture" );
 				assertDebugValue( m_isLocked, true );
@@ -372,8 +372,8 @@ namespace gl_renderer
 					, GL_TRUE );
 			}
 
-			void doSetupUpdateRegions( uint32_t offset
-				, uint32_t size )const
+			void doSetupUpdateRegions( uint64_t offset
+				, uint64_t size )const
 			{
 				assert( !m_updateRegions.empty() && "Can't update this texture." );
 				auto layerSize = m_updateRegions[0].levelSize;
@@ -599,8 +599,8 @@ namespace gl_renderer
 					, 0u );
 			}
 
-			uint8_t * lock( uint32_t offset
-				, uint32_t size
+			uint8_t * lock( uint64_t offset
+				, uint64_t size
 				, ashes::MemoryMapFlags flags )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local buffer" );
@@ -613,15 +613,15 @@ namespace gl_renderer
 				auto result = glLogCall( context
 					, glMapBufferRange
 					, GL_BUFFER_TARGET_COPY_WRITE
-					, offset
-					, size == ~( 0u ) ? m_requirements.size : size
+					, GLintptr( offset )
+					, GLsizei( size == ~( 0ull ) ? m_requirements.size : size )
 					, m_mapFlags );
 				setDebugValue( m_isLocked, result != nullptr );
 				return reinterpret_cast< uint8_t * >( result );
 			}
 
-			void flush( uint32_t offset
-				, uint32_t size )const override
+			void flush( uint64_t offset
+				, uint64_t size )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local buffer" );
 				assertDebugValue( m_isLocked, true );
@@ -629,12 +629,12 @@ namespace gl_renderer
 				glLogCall( context
 					, glFlushMappedBufferRange
 					, GL_BUFFER_TARGET_COPY_WRITE
-					, offset
-					, size == ~( 0u ) ? m_requirements.size : size );
+					, GLintptr( offset )
+					, GLsizei( size == ~( 0ull ) ? m_requirements.size : size ) );
 			}
 
-			void invalidate( uint32_t offset
-				, uint32_t size )const override
+			void invalidate( uint64_t offset
+				, uint64_t size )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local buffer" );
 				assertDebugValue( m_isLocked, true );
@@ -709,23 +709,23 @@ namespace gl_renderer
 		m_impl = std::make_unique< ImageMemory >( m_device, m_requirements, m_flags, texture, target, createInfo );
 	}
 
-	uint8_t * DeviceMemory::lock( uint32_t offset
-		, uint32_t size
+	uint8_t * DeviceMemory::lock( uint64_t offset
+		, uint64_t size
 		, ashes::MemoryMapFlags flags )const
 	{
 		assert( m_impl && "Memory object was not bound to a resource object" );
 		return m_impl->lock( offset, size, flags );
 	}
 
-	void DeviceMemory::flush( uint32_t offset
-		, uint32_t size )const
+	void DeviceMemory::flush( uint64_t offset
+		, uint64_t size )const
 	{
 		assert( m_impl && "Memory object was not bound to a resource object" );
 		m_impl->flush( offset, size );
 	}
 
-	void DeviceMemory::invalidate( uint32_t offset
-		, uint32_t size )const
+	void DeviceMemory::invalidate( uint64_t offset
+		, uint64_t size )const
 	{
 		assert( m_impl && "Memory object was not bound to a resource object" );
 		m_impl->invalidate( offset, size );

--- a/source/Ashes/Gl3Renderer/Src/Miscellaneous/GlDeviceMemory.hpp
+++ b/source/Ashes/Gl3Renderer/Src/Miscellaneous/GlDeviceMemory.hpp
@@ -32,13 +32,13 @@ namespace gl_renderer
 				, GLuint boundResource
 				, GLuint boundTarget );
 			virtual ~DeviceMemoryImpl() = default;
-			virtual uint8_t * lock( uint32_t offset
-				, uint32_t size
+			virtual uint8_t * lock( uint64_t offset
+				, uint64_t size
 				, ashes::MemoryMapFlags flags )const = 0;
-			virtual void flush( uint32_t offset
-				, uint32_t size )const = 0;
-			virtual void invalidate( uint32_t offset
-				, uint32_t size )const = 0;
+			virtual void flush( uint64_t offset
+				, uint64_t size )const = 0;
+			virtual void invalidate( uint64_t offset
+				, uint64_t size )const = 0;
 			virtual void unlock()const = 0;
 
 		protected:
@@ -63,19 +63,19 @@ namespace gl_renderer
 		/**
 		*\copydoc	ashes::DeviceMemory::lock
 		*/
-		uint8_t * lock( uint32_t offset
-			, uint32_t size
+		uint8_t * lock( uint64_t offset
+			, uint64_t size
 			, ashes::MemoryMapFlags flags )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::flush
 		*/
-		void flush( uint32_t offset
-			, uint32_t size )const override;
+		void flush( uint64_t offset
+			, uint64_t size )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::invalidate
 		*/
-		void invalidate( uint32_t offset
-			, uint32_t size )const override;
+		void invalidate( uint64_t offset
+			, uint64_t size )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::unlock
 		*/

--- a/source/Ashes/Gl4Renderer/CMakeLists.txt
+++ b/source/Ashes/Gl4Renderer/CMakeLists.txt
@@ -113,55 +113,57 @@ if ( OpenGL_FOUND )
 		PARENT_SCOPE
 	)
 
-	if ( ASHES_STATIC_RENDERERS )
-		#We install each .lib/.a in <install_dir>/lib folder
-		install(
-			TARGETS ${PROJECT_NAME}
-			COMPONENT ${PROJECT_NAME}
-			CONFIGURATIONS Release RelWithDebInfo
-			EXPORT ${PROJECT_NAME}
-			ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Release
-		)
-		install(
-			TARGETS ${PROJECT_NAME}
-			COMPONENT ${PROJECT_NAME}
-			CONFIGURATIONS Debug
-			EXPORT ${PROJECT_NAME}
-			ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Debug
-		)
-	else ()
-		if ( WIN32 )
-			#We install each .dll in <install_dir>/bin folder
+	if ( BUILD_ASHES )
+		if ( ASHES_STATIC_RENDERERS )
+			#We install each .lib/.a in <install_dir>/lib folder
 			install(
 				TARGETS ${PROJECT_NAME}
 				COMPONENT ${PROJECT_NAME}
 				CONFIGURATIONS Release RelWithDebInfo
 				EXPORT ${PROJECT_NAME}
-				RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Release
+				ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Release
 			)
 			install(
 				TARGETS ${PROJECT_NAME}
 				COMPONENT ${PROJECT_NAME}
 				CONFIGURATIONS Debug
 				EXPORT ${PROJECT_NAME}
-				RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Debug
+				ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Debug
 			)
 		else ()
-			#We install each .so in <install_dir>/lib folder
-			install(
-				TARGETS ${PROJECT_NAME}
-				COMPONENT ${PROJECT_NAME}
-				CONFIGURATIONS Release RelWithDebInfo
-				EXPORT ${PROJECT_NAME}
-				LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Release
-			)
-			install(
-				TARGETS ${PROJECT_NAME}
-				COMPONENT ${PROJECT_NAME}
-				CONFIGURATIONS Debug
-				LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Debug
-			)
-		endif()
+			if ( WIN32 )
+				#We install each .dll in <install_dir>/bin folder
+				install(
+					TARGETS ${PROJECT_NAME}
+					COMPONENT ${PROJECT_NAME}
+					CONFIGURATIONS Release RelWithDebInfo
+					EXPORT ${PROJECT_NAME}
+					RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Release
+				)
+				install(
+					TARGETS ${PROJECT_NAME}
+					COMPONENT ${PROJECT_NAME}
+					CONFIGURATIONS Debug
+					EXPORT ${PROJECT_NAME}
+					RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Debug
+				)
+			else ()
+				#We install each .so in <install_dir>/lib folder
+				install(
+					TARGETS ${PROJECT_NAME}
+					COMPONENT ${PROJECT_NAME}
+					CONFIGURATIONS Release RelWithDebInfo
+					EXPORT ${PROJECT_NAME}
+					LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Release
+				)
+				install(
+					TARGETS ${PROJECT_NAME}
+					COMPONENT ${PROJECT_NAME}
+					CONFIGURATIONS Debug
+					LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Debug
+				)
+			endif()
+		endif ()
 	endif ()
 else ()
 	if ( NOT OpenGL_FOUND )

--- a/source/Ashes/Gl4Renderer/Src/Buffer/GlUniformBuffer.cpp
+++ b/source/Ashes/Gl4Renderer/Src/Buffer/GlUniformBuffer.cpp
@@ -16,20 +16,6 @@ namespace gl_renderer
 			}();
 			return result;
 		}
-
-		uint32_t doGetAlignedSize( uint32_t size, uint32_t align )
-		{
-			uint32_t result = 0u;
-			auto align32 = uint32_t( align );
-
-			while ( size > align )
-			{
-				size -= align32;
-				result += align32;
-			}
-
-			return result + align32;
-		}
 	}
 
 	UniformBuffer::UniformBuffer( Device const & device
@@ -51,6 +37,7 @@ namespace gl_renderer
 
 	uint32_t UniformBuffer::getAlignedSize( uint32_t size )const
 	{
-		return doGetAlignedSize( size, getOffsetAlignment( m_device ) );
+		return uint32_t( ashes::getAlignedSize( size
+			, getOffsetAlignment( m_device ) ) );
 	}
 }

--- a/source/Ashes/Gl4Renderer/Src/Miscellaneous/GlDeviceMemory.cpp
+++ b/source/Ashes/Gl4Renderer/Src/Miscellaneous/GlDeviceMemory.cpp
@@ -155,8 +155,8 @@ namespace gl_renderer
 				}
 			}
 
-			uint8_t * lock( uint32_t offset
-				, uint32_t size
+			uint8_t * lock( uint64_t offset
+				, uint64_t size
 				, ashes::MemoryMapFlags flags )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local texture" );
@@ -169,16 +169,16 @@ namespace gl_renderer
 				auto result = glLogCall( context
 					, glMapBufferRange
 					, GL_BUFFER_TARGET_PIXEL_UNPACK
-					, offset
-					, size
+					, GLintptr( offset )
+					, GLsizei( size == ~( 0ull ) ? m_requirements.size : size )
 					, m_mapFlags );
 				assertDebugValue( m_isLocked, false );
 				setDebugValue( m_isLocked, result != nullptr );
 				return reinterpret_cast< uint8_t * >( result );
 			}
 
-			void flush( uint32_t offset
-				, uint32_t size )const override
+			void flush( uint64_t offset
+				, uint64_t size )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local texture" );
 				assertDebugValue( m_isLocked, true );
@@ -186,12 +186,12 @@ namespace gl_renderer
 				glLogCall( context
 					, glFlushMappedBufferRange
 					, GL_BUFFER_TARGET_PIXEL_UNPACK
-					, offset
-					, size );
+					, GLintptr( offset )
+					, GLsizei( size == ~( 0ull ) ? m_requirements.size : size ) );
 			}
 
-			void invalidate( uint32_t offset
-				, uint32_t size )const override
+			void invalidate( uint64_t offset
+				, uint64_t size )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local texture" );
 				assertDebugValue( m_isLocked, true );
@@ -199,8 +199,8 @@ namespace gl_renderer
 				glLogCall( context
 					, glInvalidateBufferSubData
 					, GL_BUFFER_TARGET_PIXEL_UNPACK
-					, offset
-					, size );
+					, GLintptr( offset )
+					, GLsizei( size == ~( 0ull ) ? m_requirements.size : size ) );
 			}
 
 			void unlock()const override
@@ -320,8 +320,8 @@ namespace gl_renderer
 					, GL_TRUE );
 			}
 
-			void doSetupUpdateRegions( uint32_t offset
-				, uint32_t size )const
+			void doSetupUpdateRegions( uint64_t offset
+				, uint64_t size )const
 			{
 				assert( !m_updateRegions.empty() && "Can't update this texture." );
 				auto layerSize = m_updateRegions[0].levelSize;
@@ -547,8 +547,8 @@ namespace gl_renderer
 					, 0u );
 			}
 
-			uint8_t * lock( uint32_t offset
-				, uint32_t size
+			uint8_t * lock( uint64_t offset
+				, uint64_t size
 				, ashes::MemoryMapFlags flags )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local buffer" );
@@ -561,15 +561,15 @@ namespace gl_renderer
 				auto result = glLogCall( context
 					, glMapBufferRange
 					, GL_BUFFER_TARGET_COPY_WRITE
-					, offset
-					, size == ~( 0u ) ? m_requirements.size : size
+					, GLintptr( offset )
+					, GLsizei( size == ~( 0ull ) ? m_requirements.size : size )
 					, m_mapFlags );
 				setDebugValue( m_isLocked, result != nullptr );
 				return reinterpret_cast< uint8_t * >( result );
 			}
 
-			void flush( uint32_t offset
-				, uint32_t size )const override
+			void flush( uint64_t offset
+				, uint64_t size )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local buffer" );
 				assertDebugValue( m_isLocked, true );
@@ -577,12 +577,12 @@ namespace gl_renderer
 				glLogCall( context
 					, glFlushMappedBufferRange
 					, GL_BUFFER_TARGET_COPY_WRITE
-					, offset
-					, size == ~( 0u ) ? m_requirements.size : size );
+					, GLintptr( offset )
+					, GLsizei( size == ~( 0ull ) ? m_requirements.size : size ) );
 			}
 
-			void invalidate( uint32_t offset
-				, uint32_t size )const override
+			void invalidate( uint64_t offset
+				, uint64_t size )const override
 			{
 				assert( checkFlag( m_flags, ashes::MemoryPropertyFlag::eHostVisible ) && "Unsupported action on a device local buffer" );
 				assertDebugValue( m_isLocked, true );
@@ -590,8 +590,8 @@ namespace gl_renderer
 				glLogCall( context
 					, glInvalidateBufferSubData
 					, GL_BUFFER_TARGET_COPY_WRITE
-					, offset
-					, size == ~( 0u ) ? m_requirements.size : size );
+					, GLintptr( offset )
+					, GLsizei( size == ~( 0ull ) ? m_requirements.size : size ) );
 			}
 
 			void unlock()const override
@@ -668,23 +668,23 @@ namespace gl_renderer
 		m_impl = std::make_unique< ImageMemory >( m_device, m_requirements, m_flags, texture, target, createInfo );
 	}
 
-	uint8_t * DeviceMemory::lock( uint32_t offset
-		, uint32_t size
+	uint8_t * DeviceMemory::lock( uint64_t offset
+		, uint64_t size
 		, ashes::MemoryMapFlags flags )const
 	{
 		assert( m_impl && "Memory object was not bound to a resource object" );
 		return m_impl->lock( offset, size, flags );
 	}
 
-	void DeviceMemory::flush( uint32_t offset
-		, uint32_t size )const
+	void DeviceMemory::flush( uint64_t offset
+		, uint64_t size )const
 	{
 		assert( m_impl && "Memory object was not bound to a resource object" );
 		m_impl->flush( offset, size );
 	}
 
-	void DeviceMemory::invalidate( uint32_t offset
-		, uint32_t size )const
+	void DeviceMemory::invalidate( uint64_t offset
+		, uint64_t size )const
 	{
 		assert( m_impl && "Memory object was not bound to a resource object" );
 		m_impl->invalidate( offset, size );

--- a/source/Ashes/Gl4Renderer/Src/Miscellaneous/GlDeviceMemory.hpp
+++ b/source/Ashes/Gl4Renderer/Src/Miscellaneous/GlDeviceMemory.hpp
@@ -32,13 +32,13 @@ namespace gl_renderer
 				, GLuint boundResource
 				, GLuint boundTarget );
 			virtual ~DeviceMemoryImpl() = default;
-			virtual uint8_t * lock( uint32_t offset
-				, uint32_t size
+			virtual uint8_t * lock( uint64_t offset
+				, uint64_t size
 				, ashes::MemoryMapFlags flags )const = 0;
-			virtual void flush( uint32_t offset
-				, uint32_t size )const = 0;
-			virtual void invalidate( uint32_t offset
-				, uint32_t size )const = 0;
+			virtual void flush( uint64_t offset
+				, uint64_t size )const = 0;
+			virtual void invalidate( uint64_t offset
+				, uint64_t size )const = 0;
 			virtual void unlock()const = 0;
 
 		protected:
@@ -63,19 +63,19 @@ namespace gl_renderer
 		/**
 		*\copydoc	ashes::DeviceMemory::lock
 		*/
-		uint8_t * lock( uint32_t offset
-			, uint32_t size
+		uint8_t * lock( uint64_t offset
+			, uint64_t size
 			, ashes::MemoryMapFlags flags )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::flush
 		*/
-		void flush( uint32_t offset
-			, uint32_t size )const override;
+		void flush( uint64_t offset
+			, uint64_t size )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::invalidate
 		*/
-		void invalidate( uint32_t offset
-			, uint32_t size )const override;
+		void invalidate( uint64_t offset
+			, uint64_t size )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::unlock
 		*/

--- a/source/Ashes/TestRenderer/CMakeLists.txt
+++ b/source/Ashes/TestRenderer/CMakeLists.txt
@@ -102,53 +102,55 @@ set( ENABLED_RENDERERS
 	PARENT_SCOPE
 )
 
-if ( ASHES_STATIC_RENDERERS )
-	#We install each .lib/.a in <install_dir>/lib folder
-	install(
-		TARGETS ${PROJECT_NAME}
-		COMPONENT ${PROJECT_NAME}
-		CONFIGURATIONS Release RelWithDebInfo
-		EXPORT ${PROJECT_NAME}
-		ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Release
-	)
-	install(
-		TARGETS ${PROJECT_NAME}
-		COMPONENT ${PROJECT_NAME}
-		CONFIGURATIONS Debug
-		EXPORT ${PROJECT_NAME}
-		ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Debug
-	)
-else ()
-	if ( WIN32 )
-		#We install each .dll in <install_dir>/bin folder
+if ( BUILD_ASHES )
+	if ( ASHES_STATIC_RENDERERS )
+		#We install each .lib/.a in <install_dir>/lib folder
 		install(
 			TARGETS ${PROJECT_NAME}
 			COMPONENT ${PROJECT_NAME}
 			CONFIGURATIONS Release RelWithDebInfo
 			EXPORT ${PROJECT_NAME}
-			RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Release
+			ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Release
 		)
 		install(
 			TARGETS ${PROJECT_NAME}
 			COMPONENT ${PROJECT_NAME}
 			CONFIGURATIONS Debug
 			EXPORT ${PROJECT_NAME}
-			RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Debug
+			ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Debug
 		)
 	else ()
-		#We install each .so in <install_dir>/lib folder
-		install(
-			TARGETS ${PROJECT_NAME}
-			COMPONENT ${PROJECT_NAME}
-			CONFIGURATIONS Release RelWithDebInfo
-			EXPORT ${PROJECT_NAME}
-			LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Release
-		)
-		install(
-			TARGETS ${PROJECT_NAME}
-			COMPONENT ${PROJECT_NAME}
-			CONFIGURATIONS Debug
-			LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Debug
-		)
-	endif()
+		if ( WIN32 )
+			#We install each .dll in <install_dir>/bin folder
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Release RelWithDebInfo
+				EXPORT ${PROJECT_NAME}
+				RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Release
+			)
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Debug
+				EXPORT ${PROJECT_NAME}
+				RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Debug
+			)
+		else ()
+			#We install each .so in <install_dir>/lib folder
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Release RelWithDebInfo
+				EXPORT ${PROJECT_NAME}
+				LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Release
+			)
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Debug
+				LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Debug
+			)
+		endif()
+	endif ()
 endif ()

--- a/source/Ashes/TestRenderer/Src/Buffer/TestUniformBuffer.cpp
+++ b/source/Ashes/TestRenderer/Src/Buffer/TestUniformBuffer.cpp
@@ -5,23 +5,6 @@
 
 namespace test_renderer
 {
-	namespace
-	{
-		uint32_t doGetAlignedSize( uint32_t size, uint32_t align )
-		{
-			uint32_t result = 0u;
-			auto align32 = uint32_t( align );
-
-			while ( size > align )
-			{
-				size -= align32;
-				result += align32;
-			}
-
-			return result + align32;
-		}
-	}
-
 	UniformBuffer::UniformBuffer( ashes::Device const & device
 		, uint32_t count
 		, uint32_t size
@@ -40,7 +23,7 @@ namespace test_renderer
 
 	uint32_t UniformBuffer::getAlignedSize( uint32_t size )const
 	{
-		return doGetAlignedSize( size
-			, uint32_t( static_cast< Device const & >( m_device ).getPhysicalDevice().getProperties().limits.minUniformBufferOffsetAlignment ) );
+		return uint32_t( ashes::getAlignedSize( size
+			, uint32_t( static_cast< Device const & >( m_device ).getPhysicalDevice().getProperties().limits.minUniformBufferOffsetAlignment ) ) );
 	}
 }

--- a/source/Ashes/TestRenderer/Src/Miscellaneous/TestDeviceMemory.cpp
+++ b/source/Ashes/TestRenderer/Src/Miscellaneous/TestDeviceMemory.cpp
@@ -21,20 +21,20 @@ namespace test_renderer
 	{
 	}
 
-	uint8_t * DeviceMemory::lock( uint32_t offset
-		, uint32_t size
+	uint8_t * DeviceMemory::lock( uint64_t offset
+		, uint64_t size
 		, ashes::MemoryMapFlags flags )const
 	{
 		return m_memory.data() + offset;
 	}
 
-	void DeviceMemory::flush( uint32_t offset
-		, uint32_t size )const
+	void DeviceMemory::flush( uint64_t offset
+		, uint64_t size )const
 	{
 	}
 
-	void DeviceMemory::invalidate( uint32_t offset
-		, uint32_t size )const
+	void DeviceMemory::invalidate( uint64_t offset
+		, uint64_t size )const
 	{
 	}
 

--- a/source/Ashes/TestRenderer/Src/Miscellaneous/TestDeviceMemory.hpp
+++ b/source/Ashes/TestRenderer/Src/Miscellaneous/TestDeviceMemory.hpp
@@ -58,19 +58,19 @@ namespace test_renderer
 		/**
 		*\copydoc	ashes::DeviceMemory::lock
 		*/
-		uint8_t * lock( uint32_t offset
-			, uint32_t size
+		uint8_t * lock( uint64_t offset
+			, uint64_t size
 			, ashes::MemoryMapFlags flags )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::flush
 		*/
-		void flush( uint32_t offset
-			, uint32_t size )const override;
+		void flush( uint64_t offset
+			, uint64_t size )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::invalidate
 		*/
-		void invalidate( uint32_t offset
-			, uint32_t size )const override;
+		void invalidate( uint64_t offset
+			, uint64_t size )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::unlock
 		*/

--- a/source/Ashes/VkRenderer/CMakeLists.txt
+++ b/source/Ashes/VkRenderer/CMakeLists.txt
@@ -103,53 +103,55 @@ set( ENABLED_RENDERERS
 	PARENT_SCOPE
 )
 
-if ( ASHES_STATIC_RENDERERS )
-	#We install each .lib/.a in <install_dir>/lib folder
-	install(
-		TARGETS ${PROJECT_NAME}
-		COMPONENT ${PROJECT_NAME}
-		CONFIGURATIONS Release RelWithDebInfo
-		EXPORT ${PROJECT_NAME}
-		ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Release
-	)
-	install(
-		TARGETS ${PROJECT_NAME}
-		COMPONENT ${PROJECT_NAME}
-		CONFIGURATIONS Debug
-		EXPORT ${PROJECT_NAME}
-		ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Debug
-	)
-else ()
-	if ( WIN32 )
-		#We install each .dll in <install_dir>/bin folder
+if ( BUILD_ASHES )
+	if ( ASHES_STATIC_RENDERERS )
+		#We install each .lib/.a in <install_dir>/lib folder
 		install(
 			TARGETS ${PROJECT_NAME}
 			COMPONENT ${PROJECT_NAME}
 			CONFIGURATIONS Release RelWithDebInfo
 			EXPORT ${PROJECT_NAME}
-			RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Release
+			ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Release
 		)
 		install(
 			TARGETS ${PROJECT_NAME}
 			COMPONENT ${PROJECT_NAME}
 			CONFIGURATIONS Debug
 			EXPORT ${PROJECT_NAME}
-			RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Debug
+			ARCHIVE DESTINATION lib/${PROJECTS_PLATFORM}/Debug
 		)
 	else ()
-		#We install each .so in <install_dir>/lib folder
-		install(
-			TARGETS ${PROJECT_NAME}
-			COMPONENT ${PROJECT_NAME}
-			CONFIGURATIONS Release RelWithDebInfo
-			EXPORT ${PROJECT_NAME}
-			LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Release
-		)
-		install(
-			TARGETS ${PROJECT_NAME}
-			COMPONENT ${PROJECT_NAME}
-			CONFIGURATIONS Debug
-			LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Debug
-		)
-	endif()
+		if ( WIN32 )
+			#We install each .dll in <install_dir>/bin folder
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Release RelWithDebInfo
+				EXPORT ${PROJECT_NAME}
+				RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Release
+			)
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Debug
+				EXPORT ${PROJECT_NAME}
+				RUNTIME DESTINATION bin/${PROJECTS_PLATFORM}/Debug
+			)
+		else ()
+			#We install each .so in <install_dir>/lib folder
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Release RelWithDebInfo
+				EXPORT ${PROJECT_NAME}
+				LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Release
+			)
+			install(
+				TARGETS ${PROJECT_NAME}
+				COMPONENT ${PROJECT_NAME}
+				CONFIGURATIONS Debug
+				LIBRARY DESTINATION lib/${PROJECTS_PLATFORM}/Debug
+			)
+		endif()
+	endif ()
 endif ()

--- a/source/Ashes/VkRenderer/Src/Buffer/VkUniformBuffer.cpp
+++ b/source/Ashes/VkRenderer/Src/Buffer/VkUniformBuffer.cpp
@@ -5,23 +5,6 @@
 
 namespace vk_renderer
 {
-	namespace
-	{
-		uint32_t doGetAlignedSize( uint32_t size, VkDeviceSize align )
-		{
-			uint32_t result = 0u;
-			auto align32 = uint32_t( align );
-
-			while ( size > align )
-			{
-				size -= align32;
-				result += align32;
-			}
-
-			return result + align32;
-		}
-	}
-
 	UniformBuffer::UniformBuffer( ashes::Device const & device
 		, uint32_t count
 		, uint32_t size
@@ -40,7 +23,7 @@ namespace vk_renderer
 
 	uint32_t UniformBuffer::getAlignedSize( uint32_t size )const
 	{
-		return doGetAlignedSize( size
-			, static_cast< Device const & >( m_device ).getPhysicalDevice().getProperties().limits.minUniformBufferOffsetAlignment );
+		return uint32_t( ashes::getAlignedSize( size
+			, uint32_t( static_cast< Device const & >( m_device ).getPhysicalDevice().getProperties().limits.minUniformBufferOffsetAlignment ) ) );
 	}
 }

--- a/source/Ashes/VkRenderer/Src/Miscellaneous/VkDeviceMemory.cpp
+++ b/source/Ashes/VkRenderer/Src/Miscellaneous/VkDeviceMemory.cpp
@@ -41,8 +41,8 @@ namespace vk_renderer
 		m_device.vkFreeMemory( m_device, m_memory, nullptr );
 	}
 
-	uint8_t * DeviceMemory::lock( uint32_t offset
-		, uint32_t size
+	uint8_t * DeviceMemory::lock( uint64_t offset
+		, uint64_t size
 		, ashes::MemoryMapFlags flags )const
 	{
 		uint8_t * pointer{ nullptr };
@@ -56,8 +56,8 @@ namespace vk_renderer
 		return pointer;
 	}
 
-	void DeviceMemory::flush( uint32_t offset
-		, uint32_t size )const
+	void DeviceMemory::flush( uint64_t offset
+		, uint64_t size )const
 	{
 		VkMappedMemoryRange mappedRange
 		{
@@ -72,8 +72,8 @@ namespace vk_renderer
 		checkError( res, "DeviceMemory range flush" );
 	}
 
-	void DeviceMemory::invalidate( uint32_t offset
-		, uint32_t size )const
+	void DeviceMemory::invalidate( uint64_t offset
+		, uint64_t size )const
 	{
 		VkMappedMemoryRange mappedRange
 		{

--- a/source/Ashes/VkRenderer/Src/Miscellaneous/VkDeviceMemory.hpp
+++ b/source/Ashes/VkRenderer/Src/Miscellaneous/VkDeviceMemory.hpp
@@ -57,19 +57,19 @@ namespace vk_renderer
 		/**
 		*\copydoc	ashes::DeviceMemory::lock
 		*/
-		uint8_t * lock( uint32_t offset
-			, uint32_t size
+		uint8_t * lock( uint64_t offset
+			, uint64_t size
 			, ashes::MemoryMapFlags flags )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::flush
 		*/
-		void flush( uint32_t offset
-			, uint32_t size )const override;
+		void flush( uint64_t offset
+			, uint64_t size )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::invalidate
 		*/
-		void invalidate( uint32_t offset
-			, uint32_t size )const override;
+		void invalidate( uint64_t offset
+			, uint64_t size )const override;
 		/**
 		*\copydoc	ashes::DeviceMemory::unlock
 		*/


### PR DESCRIPTION
DeviceMemory and Buffer lock, flush and invalidate functions now take uint64_t parameters, like Vulkan expects.
Added a way to compute an aligned size for Buffer<T> and VertexBuffer<T>, to prevent validation errors.
Fixed installation of plugins.